### PR TITLE
Need to abolish the weak reference

### DIFF
--- a/Sources/Classes/UITabBarController+Shari.swift
+++ b/Sources/Classes/UITabBarController+Shari.swift
@@ -28,10 +28,9 @@ public extension Shari where Base: UITabBarController {
             toView: viewControllerToPresent.view,
             fromView: parentTargetView,
             visibleHeight: visibleHeight,
-            completion: { [weak self] in
-                guard let strongslef = self else { return }
+            completion: {
                 viewControllerToPresent.endAppearanceTransition()
-                viewControllerToPresent.didMove(toParent: strongslef.base)
+                viewControllerToPresent.didMove(toParent: self.base)
         })
 
         let tapGestureRecognizer = UITapGestureRecognizer(


### PR DESCRIPTION
The pop animation doesn't work well when we use the weak reference in completion block .
As a last resort, we use the circular reference.
