### PR TITLE
Can not update cornerRadius

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ env:
       - DESTINATION="platform=iOS Simulator,name=iPhone X"
 
 install:
-  - gem install xcpretty --no-rdoc --no-ri --no-document --quiet
+  - gem install xcpretty 
 
 script:
   - rake test:framework DESTINATION="$DESTINATION"

--- a/Sources/Classes/ShariNavigationController.swift
+++ b/Sources/Classes/ShariNavigationController.swift
@@ -40,18 +40,14 @@ public class ShariNavigationController: UINavigationController {
         )
         view.addGestureRecognizer(panGestureRecognizer)
 
-        if cornerRadius > 0 {
-            view.layer.cornerRadius = cornerRadius
-            view.clipsToBounds = true
-            ModalAnimator.cornerRadius = cornerRadius
-        }
-
         NotificationCenter.default.addObserver(
             self,
             selector: #selector(self.orientationDidChanged(_:)),
             name: UIDevice.orientationDidChangeNotification,
             object: nil
         )
+
+        updateLayoutIfNeeded()
     }
 
     deinit {
@@ -215,6 +211,14 @@ public class ShariNavigationController: UINavigationController {
             containerFrame: backgroundView.bounds,
             visibleHeight: height
         )
+    }
+
+    public func updateLayoutIfNeeded() {
+        if cornerRadius > 0 {
+            view.layer.cornerRadius = cornerRadius
+            view.clipsToBounds = true
+            ModalAnimator.cornerRadius = cornerRadius
+        }
     }
     
 }


### PR DESCRIPTION
We can not update the corner radius when we directly use initializer but not use with storyboard.


# resolution

```swift
        // Transition Setting
        ShariSettings.shouldTransformScaleDown = false
        ShariSettings.backgroundColorOfOverlayView = UIColor(red: 0, green: 0, blue: 0, alpha: 0.6)
        ShariSettings.isUsingScreenShotImage = false

       let viewController = storyboard!.instantiateViewController(withIdentifier: "ModalV2TableViewController") as! ModalV2TableViewController
        let modalNavigationController = ShariNavigationController(rootViewController: viewController)
        
        modalNavigationController.parentNavigationController = navigationController
        modalNavigationController.cornerRadius = 8
        modalNavigationController.updateLayoutIfNeeded()
        navigationController?.si.present(modalNavigationController)
```